### PR TITLE
add System.PosixCompat.Process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## Version 0.7.1 (2023-11-01)
+
+- Add `System.PosixCompat.Process` module, exporting `getProcessID`
+
 ## Version 0.7 (2023-03-15)
 
-- Remote `System.PosixCompat.User` module
+- Remove `System.PosixCompat.User` module
 
 ## Version 0.6 (2022-05-22)
 

--- a/src/System/PosixCompat.hs
+++ b/src/System/PosixCompat.hs
@@ -7,6 +7,7 @@ package, on other platforms it emulates the operations as far as possible.
 -}
 module System.PosixCompat (
       module System.PosixCompat.Files
+    , module System.PosixCompat.Process
     , module System.PosixCompat.Temp
     , module System.PosixCompat.Time
     , module System.PosixCompat.Types
@@ -15,6 +16,7 @@ module System.PosixCompat (
     ) where
 
 import System.PosixCompat.Files
+import System.PosixCompat.Process
 import System.PosixCompat.Temp
 import System.PosixCompat.Time
 import System.PosixCompat.Types

--- a/src/System/PosixCompat/Process.hs
+++ b/src/System/PosixCompat/Process.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+
+{-|
+This module intends to make the operations of @System.Posix.Process@ available
+on all platforms.
+-}
+module System.PosixCompat.Process (
+      getProcessID
+    ) where
+
+#ifdef mingw32_HOST_OS
+
+import System.Posix.Types (ProcessID)
+import System.Win32.Process (getCurrentProcessId)
+
+getProcessID :: IO ProcessID
+getProcessID = fromIntegral <$> getCurrentProcessId
+
+#else
+
+import System.Posix.Process
+
+#endif

--- a/tests/ProcessSpec.hs
+++ b/tests/ProcessSpec.hs
@@ -1,0 +1,12 @@
+module ProcessSpec (processSpec) where
+
+import System.PosixCompat
+import Test.HUnit
+import Test.Hspec
+
+processSpec :: Spec
+processSpec = do
+  describe "getProcessID" $ do
+    it "should work on Windows and Unix" $ do
+      id <- getProcessID
+      assert $ id > 0

--- a/tests/main.hs
+++ b/tests/main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import MkstempSpec
 import LinksSpec
+import ProcessSpec
 
 import Test.Hspec
 
@@ -9,3 +10,4 @@ main :: IO ()
 main = hspec $ do
     mkstempSpec
     linksSpec
+    processSpec

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -1,5 +1,5 @@
 name:           unix-compat
-version:        0.7
+version:        0.7.1
 synopsis:       Portable POSIX-compatibility layer.
 description:    This package provides portable implementations of parts
                 of the unix package. This package re-exports the unix
@@ -36,6 +36,7 @@ Library
     System.PosixCompat
     System.PosixCompat.Extensions
     System.PosixCompat.Files
+    System.PosixCompat.Process
     System.PosixCompat.Temp
     System.PosixCompat.Time
     System.PosixCompat.Types
@@ -85,6 +86,7 @@ Test-Suite unix-compat-testsuite
   other-modules:
      MkstempSpec
      LinksSpec
+     ProcessSpec
 
   -- ghc-options:
   --   -Wall


### PR DESCRIPTION
This PR adds the `getProcessID` function which is supported on both Unix and Win32 systems. It is already used by `lsp-test` and `lsp-client`.