### PR TITLE
v0.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,28 @@ jobs:
     name: ${{ matrix.os }} - GHC ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc:
-          - 9.8
-          - 9.6
-          - 9.4
-          - 9.2
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # Check the haddock step below which is limited to a single GHC version!
+        ghc:
+          - '9.10'
+          - '9.8'
+          - '9.6'
+          - '9.4'
+          - '9.2'
+          - '9.0'
+          - '8.10'
+          - '8.8'
+          - '8.6'
+          - '8.4'
+          - '8.2'
+          - '8.0'
+        include:
+          - os: macos-latest
+            ghc: '9.10'
+          - os: windows-latest
+            ghc: '9.10'
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +48,7 @@ jobs:
         cabal build all --dry-run
 
     - name: Restore cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       id:   cache
       with:
         path: ${{ steps.setup.outputs.cabal-store }}
@@ -48,12 +62,13 @@ jobs:
     - run: cabal build all
     - run: cabal test all
     - run: cabal haddock
+      if:  matrix.ghc == '9.8'
     - run: cabal check
     - run: cabal sdist
 
     - name: Save cache
-      uses: actions/cache/save@v3
-      if:   always()
+      uses: actions/cache/save@v4
+      if:   always() && steps.cache.outputs.cache-hit != 'true'
       with:
         key:  ${{ steps.cache.outputs.cache-primary-key }}
         path: ${{ steps.setup.outputs.cabal-store }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,163 @@
+name: stack
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack:
+    name: Stack ${{ matrix.ghc }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+        - os: macos-latest
+          ghc: 9.8.2
+          resolver: nightly-2024-06-22
+        - os: macos-latest
+          ghc: 9.2.8
+          resolver: lts-20.26
+          # GHC < 9.2 not supported on macos-14 ARM runner
+          # https://github.com/haskell-actions/setup/issues/77
+
+        - os: windows-latest
+          ghc: 9.8.2
+          resolver: nightly-2024-06-22
+        - os: windows-latest
+          ghc: 8.4.4
+          resolver: lts-12.26
+
+        - os: ubuntu-latest
+          ghc: 9.8.2
+          resolver: nightly-2024-06-22
+        - os: ubuntu-latest
+          ghc: 9.6.5
+          resolver: lts-22.26
+        - os: ubuntu-latest
+          ghc: 9.4.8
+          resolver: lts-21.25
+        - os: ubuntu-latest
+          ghc: 9.2.8
+          resolver: lts-20.26
+        - os: ubuntu-latest
+          ghc: 9.0.2
+          resolver: lts-19.33
+        - os: ubuntu-latest
+          ghc: 8.10.7
+          resolver: lts-18.28
+        - os: ubuntu-latest
+          ghc: 8.8.4
+          resolver: lts-16.31
+        - os: ubuntu-latest
+          ghc: 8.6.5
+          resolver: lts-14.27
+        - os: ubuntu-latest
+          ghc: 8.4.4
+          resolver: lts-12.26
+
+        # Tests need directory-1.3.1.0 which entered LTS for GHC 8.4.
+        # - os: ubuntu-latest
+        #   ghc: 8.2.2
+        #   resolver: lts-11.22
+        # - os: ubuntu-latest
+        #   ghc: 8.0.2
+        #   resolver: lts-9.21
+
+    env:
+      stack: 'stack --system-ghc --no-install-ghc'
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Install GHC and stack with haskell-actions/setup
+      uses: haskell-actions/setup@v2
+      id:   setup
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
+        cabal-update: false
+
+    - name: Create stack.yaml
+      run: |
+        cat > stack.yaml <<EOF
+        resolver: ${{ matrix.resolver }}
+        compiler: ghc-${{ matrix.ghc }}
+        packages: [.]
+        EOF
+
+    # According to https://github.com/commercialhaskell/stack/issues/5754#issuecomment-1696156869
+    # not all of ~/.stack should be cached,
+    # only the index (pantry) and the dependencies (sqlite3+snapshots).
+
+    ## Pantry
+    ########################################################################
+
+    - name: Restore cached stack pantry
+      uses: actions/cache/restore@v4
+      id:   cache-pantry
+      with:
+        path: ${{ steps.setup.outputs.stack-root }}/pantry
+        key:  ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-pantry-resolver-${{ matrix.resolver }}
+        # No fall-back keys here!
+
+    - name: Stack update
+      if:   steps.cache-pantry.outputs.cache-hit != 'true'
+      run:  ${{ env.stack }} update
+
+    - name: Cache stack pantry
+      if:   steps.cache-pantry.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.setup.outputs.stack-root }}/pantry
+        key:  ${{ steps.cache-pantry.outputs.cache-primary-key }}
+
+    ## Dependencies
+    ########################################################################
+
+    - name: Stack build plan
+      run:  ${{ env.stack }} test --dry-run > '.build-plan.txt'
+
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
+      id:   cache-deps
+      with:
+        path: |
+          ${{ steps.setup.outputs.stack-root }}/stack.sqlite3
+          ${{ steps.setup.outputs.stack-root }}/snapshots
+        key: ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}-resolver-${{ matrix.resolver }}-plan-${{ hashfiles('.build-plan.txt') }}
+        restore-keys: |
+             ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}-resolver-${{ matrix.resolver }}-
+             ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}-
+
+    - name: Build dependencies
+      if:   steps.cache-deps.outputs.cache-hit != 'true'
+      run:  ${{ env.stack }} test --dependencies-only
+
+    - name: Cache dependencies
+      if:   steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ steps.setup.outputs.stack-root }}/stack.sqlite3
+          ${{ steps.setup.outputs.stack-root }}/snapshots
+        key:  ${{ steps.cache-deps.outputs.cache-primary-key }}
+
+    ## Build and test STMonadTrans
+    ########################################################################
+
+    - name: Build w/ tests
+      run: ${{ env.stack }} test --no-run-tests
+
+    - name: Run tests
+      run: ${{ env.stack }} test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
+## Version 0.7.2 (2024-06-25)
+
+- Remove flag `old-time` and drop support for `old-time`.
+- Remove support for GHC 7.
+- Tested with GHC 8.0 - 9.10.
+
 ## Version 0.7.1 (2023-12-06) Santa Clause edition
 
-- Add `System.PosixCompat.Process` module, exporting `getProcessID`
+- Add `System.PosixCompat.Process` module, exporting `getProcessID`.
 
 ## Version 0.7 (2023-03-15)
 
-- Remove `System.PosixCompat.User` module
+- Remove `System.PosixCompat.User` module.
 
 ## Version 0.6 (2022-05-22)
 
-- Better support for symbolic links
+- Better support for symbolic links.

--- a/src/System/PosixCompat/Internal/Time.hs
+++ b/src/System/PosixCompat/Internal/Time.hs
@@ -10,16 +10,6 @@ module System.PosixCompat.Internal.Time (
     ) where
 
 import System.Posix.Types (EpochTime)
-
-#ifdef OLD_TIME
-
-import System.Time (ClockTime(TOD), getClockTime)
-
-clockTimeToEpochTime :: ClockTime -> EpochTime
-clockTimeToEpochTime (TOD s _) = fromInteger s
-
-#else
-
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 
 type ClockTime = POSIXTime
@@ -29,5 +19,3 @@ getClockTime = getPOSIXTime
 
 clockTimeToEpochTime :: ClockTime -> EpochTime
 clockTimeToEpochTime = fromInteger . floor
-
-#endif

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -1,5 +1,6 @@
+cabal-version:  >= 1.10
 name:           unix-compat
-version:        0.7.1
+version:        0.7.2
 synopsis:       Portable POSIX-compatibility layer.
 description:    This package provides portable implementations of parts
                 of the unix package. This package re-exports the unix
@@ -13,7 +14,6 @@ author:         Björn Bringert, Duncan Coutts, Jacob Stanley, Bryan O'Sullivan
 maintainer:     https://github.com/haskell-pkg-janitors
 category:       System
 build-type:     Simple
-cabal-version:  >= 1.10
 
 tested-with:
   GHC == 9.10.1
@@ -36,15 +36,8 @@ source-repository head
   type:     git
   location: https://github.com/haskell-pkg-janitors/unix-compat.git
 
-flag old-time
-  description: build against old-time package
-  default: False
-
 Library
-  default-language: Haskell2010
   hs-source-dirs: src
-  ghc-options: -Wall
-  build-depends: base == 4.*
 
   exposed-modules:
     System.PosixCompat
@@ -56,27 +49,18 @@ Library
     System.PosixCompat.Types
     System.PosixCompat.Unistd
 
+  build-depends: base >= 4.9 && < 5
+
   if os(windows)
     c-sources:
       cbits/HsUname.c
       cbits/mktemp.c
 
     extra-libraries: msvcrt
-    build-depends: Win32 >= 2.5.0.0
-    build-depends: filepath >= 1.0 && < 1.5
-
-    if flag(old-time)
-      build-depends: old-time >= 1.0.0.0 && < 1.2.0.0
-      cpp-options: -DOLD_TIME
-
-      if impl(ghc < 7)
-        build-depends: directory == 1.0.*
-        cpp-options: -DDIRECTORY_1_0
-      else
-        build-depends: directory == 1.1.*
-    else
-      build-depends: time >= 1.0 && < 1.13
-      build-depends: directory >= 1.3.1 && < 1.4
+    build-depends: Win32     >= 2.5.0.0
+    build-depends: directory >= 1.3.1    && < 1.4
+    build-depends: filepath  >= 1.0      && < 1.6
+    build-depends: time      >= 1.0      && < 1.13
 
     other-modules:
       System.PosixCompat.Internal.Time
@@ -90,11 +74,14 @@ Library
     if os(solaris)
       cc-options: -DSOLARIS
 
-Test-Suite unix-compat-testsuite
   default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+
+Test-Suite unix-compat-testsuite
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
-  ghc-options: -Wall
   main-is: main.hs
 
   other-modules:
@@ -119,11 +106,12 @@ Test-Suite unix-compat-testsuite
 
   build-depends:
       unix-compat
-    , base == 4.*
+    , base
     , monad-parallel
     , hspec
     , HUnit
-    , directory
+    , directory >= 1.3.1.0
+        -- directory-1.3.1.0 adds createFileLink
     , extra
     , temporary
 
@@ -134,19 +122,8 @@ Test-Suite unix-compat-testsuite
 
     -- extra-libraries: msvcrt
     -- build-depends: Win32 >= 2.5.0.0
-
-    if flag(old-time)
-      build-depends: old-time >= 1.0.0.0 && < 1.2.0.0
-      cpp-options: -DOLD_TIME
-
-      if impl(ghc < 7)
-        build-depends: directory == 1.0.*
-        cpp-options: -DDIRECTORY_1_0
-      else
-        build-depends: directory == 1.1.*
-    else
-      build-depends: time >= 1.0 && < 1.13
-      build-depends: directory >= 1.3.1 && < 1.4
+      build-depends: time
+      build-depends: directory
 
     -- other-modules:
     --   System.PosixCompat.Internal.Time
@@ -160,4 +137,7 @@ Test-Suite unix-compat-testsuite
     if os(solaris)
       cc-options: -DSOLARIS
 
-    build-depends: directory >= 1.3.1 && < 1.4
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -15,6 +15,20 @@ category:       System
 build-type:     Simple
 cabal-version:  >= 1.10
 
+tested-with:
+  GHC == 9.10.1
+  GHC == 9.8.2
+  GHC == 9.6.5
+  GHC == 9.4.8
+  GHC == 9.2.8
+  GHC == 9.0.2
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+
 extra-source-files:
   CHANGELOG.md
 


### PR DESCRIPTION
Cover all GHC 8 and 9 versions on ubuntu CI.
Add stack CI.
Relax Windows dependencies (`filepath`).

Closes #10.

RC: https://hackage.haskell.org/package/unix-compat-0.7.2/candidate