### PR TITLE
fix: allow time-1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest]
         # Check the haddock step below which is limited to a single GHC version!
         ghc:
+          - '9.12'
           - '9.10'
           - '9.8'
           - '9.6'
           - '9.4'
-          - '9.2'
-          - '9.0'
-          - '8.10'
-          - '8.8'
-          - '8.6'
-          - '8.4'
-          - '8.2'
+          # - '9.2'
+          # - '9.0'
+          # - '8.10'
+          # - '8.8'
+          # - '8.6'
+          # - '8.4'
+          # - '8.2'
           - '8.0'
         include:
           - os: macos-latest
-            ghc: '9.10'
-          - os: windows-latest
-            ghc: '9.10'
+            ghc: '9.12'
+          - os: ubuntu-latest
+            ghc: '9.12'
 
     steps:
     - uses: actions/checkout@v4
@@ -60,9 +61,10 @@ jobs:
       run: cabal build all --dependencies-only
 
     - run: cabal build all
+    - run: cabal build all --enable-tests
     - run: cabal test all
     - run: cabal haddock
-      if:  matrix.ghc == '9.8'
+      if:  matrix.ghc == '9.12'
     - run: cabal check
     - run: cabal sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,18 @@ jobs:
           - '9.12'
           - '9.10'
           - '9.8'
-          - '9.6'
-          - '9.4'
+          # - '9.6'
+          # - '9.4'
           # - '9.2'
           # - '9.0'
           # - '8.10'
           # - '8.8'
           # - '8.6'
-          # - '8.4'
+          - '8.4'
+          # hsc2hs fails on windows-2022 for GHCs 8.0 and 8.2
+          # https://github.com/haskell/hsc2hs/issues/81
           # - '8.2'
-          - '8.0'
+          # - '8.0'
         include:
           - os: macos-latest
             ghc: '9.12'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241205
+# version: 0.19.20241223
 #
-# REGENDATA ("0.19.20241205",["github","unix-compat.cabal"])
+# REGENDATA ("0.19.20241223",["github","unix-compat.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,10 +32,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.0.20241128
+          - compiler: ghc-9.12.1
             compilerKind: ghc
-            compilerVersion: 9.12.0.20241128
-            setup-method: ghcup-prerelease
+            compilerVersion: 9.12.1
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
@@ -110,26 +110,11 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
-          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-        env:
-          HCKIND: ${{ matrix.compilerKind }}
-          HCNAME: ${{ matrix.compiler }}
-          HCVER: ${{ matrix.compilerVersion }}
-      - name: Install GHC (GHCup prerelease)
-        if: matrix.setup-method == 'ghcup-prerelease'
-        run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -151,7 +136,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 80400)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -179,18 +164,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -242,9 +215,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(unix-compat)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -23,10 +23,10 @@ jobs:
 
         - os: macos-latest
           ghc: 9.10.1
-          resolver: nightly-2024-12-12
+          resolver: nightly-2025-01-16
         - os: macos-latest
           ghc: 9.8.4
-          resolver: lts-23.0
+          resolver: lts-23.4
         - os: macos-latest
           ghc: 9.2.8
           resolver: lts-20.26
@@ -35,20 +35,20 @@ jobs:
 
         - os: windows-latest
           ghc: 9.10.1
-          resolver: nightly-2024-12-12
+          resolver: nightly-2025-01-16
         - os: windows-latest
           ghc: 9.8.4
-          resolver: lts-23.0
+          resolver: lts-23.4
         - os: windows-latest
           ghc: 8.4.4
           resolver: lts-12.26
 
         - os: ubuntu-latest
           ghc: 9.10.1
-          resolver: nightly-2024-12-12
+          resolver: nightly-2025-01-16
         - os: ubuntu-latest
           ghc: 9.8.4
-          resolver: lts-23.0
+          resolver: lts-23.4
         - os: ubuntu-latest
           ghc: 9.6.6
           resolver: lts-22.43

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -1,6 +1,7 @@
 cabal-version:  >= 1.10
 name:           unix-compat
 version:        0.7.3
+x-revision:     1
 synopsis:       Portable POSIX-compatibility layer.
 description:    This package provides portable implementations of parts
                 of the unix package. This package re-exports the unix
@@ -16,7 +17,7 @@ category:       System
 build-type:     Simple
 
 tested-with:
-  GHC == 9.12.0
+  GHC == 9.12.1
   GHC == 9.10.1
   GHC == 9.8.4
   GHC == 9.6.6

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -61,7 +61,7 @@ Library
     build-depends: Win32     >= 2.5.0.0  && < 3
     build-depends: directory >= 1.3.1    && < 1.4
     build-depends: filepath  >= 1.4.1.0  && < 1.6
-    build-depends: time      >= 1.6.0.1  && < 1.13
+    build-depends: time      >= 1.6.0.1  && < 1.15
 
     other-modules:
       System.PosixCompat.Internal.Time

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -109,7 +109,7 @@ Test-Suite unix-compat-testsuite
       unix-compat
     , base
     , monad-parallel
-    , hspec
+    , hspec >= 2.5.5
     , HUnit
     , directory >= 1.3.1.0
         -- directory-1.3.1.0 adds createFileLink


### PR DESCRIPTION
Because, GHC 9.12 time library version is 1.14.

> time 1.14 Dependency of ghc library
>
> [GHC 9.12.20241014](https://downloads.haskell.org/ghc/9.12.1-alpha1/docs/users_guide/9.12.1-notes.html)
