### PR TITLE
Skip major/minor/makedev on WASM

### DIFF
--- a/.github/workflows/ci-wasm32-wasi.yml
+++ b/.github/workflows/ci-wasm32-wasi.yml
@@ -1,0 +1,27 @@
+name: CI (wasm32-wasi)
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GHC_WASM_META: 45f73c3e075fa38efe84055b0dba87996948101d
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+
+      - name: Build
+        run: |
+          nix shell "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org&rev=${GHC_WASM_META}"#{wasmtime,wasm32-wasi-cabal-9_12,wasm32-wasi-ghc-9_12} --command \
+            wasm32-wasi-cabal update
+          nix shell "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org&rev=${GHC_WASM_META}"#{wasmtime,wasm32-wasi-cabal-9_12,wasm32-wasi-ghc-9_12} --command \
+            wasm32-wasi-cabal build
+
+      - name: Test
+        run: |
+          nix shell "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org&rev=${GHC_WASM_META}"#{wasmtime,wasm32-wasi-cabal-9_12,wasm32-wasi-ghc-9_12} --command \
+            wasm32-wasi-cabal test --test-wrapper ./tests/run-wasmtime.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - Add wasm32-wasi support.
+
 ## Version 0.7.3 (2024-10-11)
 
 - Fix `sysmacros.h` include for GNU/Hurd

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: unix-compat.cabal
+
+if arch(wasm32)
+  -- See https://github.com/haskellari/splitmix/pull/73
+  source-repository-package
+    type:     git
+    location: https://github.com/amesgen/splitmix.git
+    tag:      cea9e31bdd849eb0c17611bb99e33d590e126164

--- a/include/HsUnixCompat.h
+++ b/include/HsUnixCompat.h
@@ -4,5 +4,3 @@
 unsigned int unix_major(dev_t dev);
 unsigned int unix_minor(dev_t dev);
 dev_t unix_makedev(unsigned int maj, unsigned int min);
-
-#define NEED_setSymbolicLinkOwnerAndGroup !HAVE_LCHOWN

--- a/src/System/PosixCompat/Extensions.hsc
+++ b/src/System/PosixCompat/Extensions.hsc
@@ -12,7 +12,7 @@ module System.PosixCompat.Extensions (
     ) where
 
 
-#ifndef mingw32_HOST_OS
+#if !(defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH))
 #include "HsUnixCompat.h"
 #endif
 
@@ -27,7 +27,7 @@ type CMinor = CUInt
 --
 -- The portable implementation always returns @0@.
 deviceMajor :: DeviceID -> CMajor
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH)
 deviceMajor _ = 0
 #else
 deviceMajor dev = unix_major dev
@@ -39,7 +39,7 @@ foreign import ccall unsafe "unix_major" unix_major :: CDev -> CUInt
 --
 -- The portable implementation always returns @0@.
 deviceMinor :: DeviceID -> CMinor
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH)
 deviceMinor _ = 0
 #else
 deviceMinor dev = unix_minor dev
@@ -49,7 +49,7 @@ foreign import ccall unsafe "unix_minor" unix_minor :: CDev -> CUInt
 
 -- | Creates a 'DeviceID' for a device file given a major and minor number.
 makeDeviceID :: CMajor -> CMinor -> DeviceID
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH)
 makeDeviceID _ _ = 0
 #else
 makeDeviceID ma mi = unix_makedev ma mi

--- a/src/System/PosixCompat/Files.hsc
+++ b/src/System/PosixCompat/Files.hsc
@@ -106,11 +106,11 @@ module System.PosixCompat.Files (
 
 #ifndef mingw32_HOST_OS
 
-#include "HsUnixCompat.h"
+#include "HsUnixConfig.h"
 
 import System.Posix.Files
 
-#if NEED_setSymbolicLinkOwnerAndGroup
+#if !HAVE_LCHOWN
 import System.PosixCompat.Types
 
 setSymbolicLinkOwnerAndGroup :: FilePath -> UserID -> GroupID -> IO ()

--- a/src/System/PosixCompat/Process.hs
+++ b/src/System/PosixCompat/Process.hs
@@ -8,13 +8,20 @@ module System.PosixCompat.Process (
       getProcessID
     ) where
 
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS)
 
 import System.Posix.Types (ProcessID)
 import System.Win32.Process (getCurrentProcessId)
 
 getProcessID :: IO ProcessID
 getProcessID = fromIntegral <$> getCurrentProcessId
+
+#elif defined(wasm32_HOST_ARCH)
+
+import System.Posix.Types (ProcessID)
+
+getProcessID :: IO ProcessID
+getProcessID = pure 1
 
 #else
 

--- a/src/System/PosixCompat/Temp.hs
+++ b/src/System/PosixCompat/Temp.hs
@@ -11,13 +11,13 @@ module System.PosixCompat.Temp (
       mkstemp
     ) where
 
-#ifndef mingw32_HOST_OS
+#if !(defined(mingw32_HOST_OS) || defined(wasm32_HOST_ARCH))
 -- Re-export unix package
 
 import System.Posix.Temp
 
 #elif defined(__GLASGOW_HASKELL__)
--- Windows w/ GHC, we have fdToHandle so we
+-- Window/WASM w/ GHC, we have fdToHandle so we
 -- can use our own implementation of mkstemp.
 
 import System.IO (Handle)

--- a/tests/run-wasmtime.sh
+++ b/tests/run-wasmtime.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+TMP="$(mktemp -d --suffix=-unix-compat)"
+trap 'rm -rf -- "$TMP"' EXIT
+wasmtime --dir "$TMP::/" "$@"
+exit "$?"

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -69,10 +69,11 @@ Library
 
   else
     build-depends: unix      >= 2.7.2.0  && < 2.9
-    include-dirs: include
-    includes: HsUnixCompat.h
-    install-includes: HsUnixCompat.h
-    c-sources: cbits/HsUnixCompat.c
+    if !arch(wasm32)
+      include-dirs: include
+      includes: HsUnixCompat.h
+      install-includes: HsUnixCompat.h
+      c-sources: cbits/HsUnixCompat.c
     if os(solaris)
       cc-options: -DSOLARIS
 

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -69,11 +69,11 @@ Library
 
   else
     build-depends: unix      >= 2.7.2.0  && < 2.9
+    include-dirs: include
+    includes: HsUnixCompat.h
+    install-includes: HsUnixCompat.h
     if !arch(wasm32)
-      include-dirs: include
-      includes: HsUnixCompat.h
-      install-includes: HsUnixCompat.h
-      c-sources: cbits/HsUnixCompat.c
+       c-sources: cbits/HsUnixCompat.c
     if os(solaris)
       cc-options: -DSOLARIS
 

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -69,7 +69,9 @@ Library
 
   else
     build-depends: unix      >= 2.7.2.0  && < 2.9
-    if !arch(wasm32)
+    if arch(wasm32)
+      c-sources: cbits/mktemp.c
+    else
       include-dirs: include
       includes: HsUnixCompat.h
       install-includes: HsUnixCompat.h

--- a/unix-compat.cabal
+++ b/unix-compat.cabal
@@ -69,11 +69,11 @@ Library
 
   else
     build-depends: unix      >= 2.7.2.0  && < 2.9
-    include-dirs: include
-    includes: HsUnixCompat.h
-    install-includes: HsUnixCompat.h
     if !arch(wasm32)
-       c-sources: cbits/HsUnixCompat.c
+      include-dirs: include
+      includes: HsUnixCompat.h
+      install-includes: HsUnixCompat.h
+      c-sources: cbits/HsUnixCompat.c
     if os(solaris)
       cc-options: -DSOLARIS
 


### PR DESCRIPTION
WebAssembly/WASI does not have `makedev` and friends. When targetting WASI, we skip building `HsUnixCompat.c` and (like with Windows) just provide dummy implementations instead.

This removes the `NEED_setSymbolicLinkOwnerAndGroup` macro from `HsUnixCompat.h` as we can no longer rely on that file existing, and so inline the definition directly into `Files.hsc`. I do not believe any other packages rely on this macro existing, so this should not cause any breakage.

However, if preferred, I'm happy to revert this, and instead put the definitions of `unix_makedev` inside a `#ifndef wasm32_HOST_ARCH`.